### PR TITLE
New Feature: Failed Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 - added 'failed mode'. This Mode checks all systemd service and reports only CRITICAL if any service has state "failed" (@Seji64)
 
 ### Fixed
-- check-systemd.rb: NilClass Exception when no service (-s) is set
+- check-systemd.rb: NilClass Exception when no service (-s) is set (@Seji64)
 
 ## [0.1.0] - 2017-09-10
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Which is based on [Keep A Changelog](http://keepachangelog.com/)
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
+- added 'failed mode'. This Mode checks all systemd service and reports only CRITICAL if any service has state "failed" (@Seji64)
+
+### Fixed
+- check-systemd.rb: NilClass Exception when no service (-s) is set
 
 ## [0.1.0] - 2017-09-10
 ### Added

--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ Pass services as a comma delimited -s option
 check-systemd.rb -s SERVICE1.service,SERVICE2.service
 ```
 
+### Usage/example failed mode
+All services with state 'failed' will be reported as CRITICAL except kdump.service
+
+```
+check-systemd.rb -f -i kdump.service
+```
+
 ## Installation
 
 [Installation and Setup](http://sensu-plugins.io/docs/installation_instructions.html)

--- a/bin/check-systemd.rb
+++ b/bin/check-systemd.rb
@@ -87,7 +87,7 @@ class CheckSystemd < Sensu::Plugin::Check::CLI
   def check_systemd
     unless @services.nil?
       @services.reject { |service| validate_presence_of(service) }.each do |gone|
-         @crit_service << "#{gone} - Not Present"
+        @crit_service << "#{gone} - Not Present"
       end
     end
     if @services.none? && @failed == false

--- a/bin/check-systemd.rb
+++ b/bin/check-systemd.rb
@@ -16,6 +16,8 @@
 #
 # USAGE:
 # -s SERVICE - Services to check delimited by commas
+# -f Toogle 'failed mode'
+# -i SERVICES - Services to ignore in 'failed mode'. delimited by commas
 #
 # LICENSE:
 #   Chris McFee <cmcfee@kent.edu>

--- a/bin/check-systemd.rb
+++ b/bin/check-systemd.rb
@@ -31,13 +31,29 @@ require 'sensu-plugin/check/cli'
 class CheckSystemd < Sensu::Plugin::Check::CLI
   option :services,
          short: '-s SERVICES',
-         proc: proc { |a| a.split(',') }
+         proc: proc { |a| a.split(',')},
+         default: [],
+         description: 'comma seperated list of services to check. ignored if --failed is set'
+  option :failed,
+         short: '-f',
+         boolean: true,
+         default: false,
+         long: '--failed',
+         description: 'all services are being checked. One or more failed => CRITICAL'
+  option :failed_ignore,
+         short: '-i SERVICES',
+         proc: proc { |a| a.split(',')},
+         default: [],
+         long: '--failed-ignore',
+         description: 'comma seperated list of services which should be ignored when using --failed mode'
 
   # Setup variables
   #
   def initialize
     super
     @services = config[:services]
+    @failed = config[:failed]
+    @failed_ignore =  config[:failed_ignore]
     @crit_service = []
   end
 
@@ -53,21 +69,28 @@ class CheckSystemd < Sensu::Plugin::Check::CLI
     service_array = []
     systemd_output.split("\n").each do |line|
       line_array = line.split(' ')
-      next unless @services.any? { |service| line_array[0].include?(service) }
-      service_hash = {}
-      service_hash['name'] = line_array[0]
-      service_hash['load'] = line_array[1]
-      service_hash['active'] = line_array[2]
-      service_hash['sub'] = line_array[3]
-      service_hash['description'] = line_array[4]
-      service_array.push(service_hash)
+      next unless @services.any? { |service| line_array[0].include?(service) } || @failed == true
+      unless @failed_ignore.any? { |service| line_array[0].include?(service) } && @failed == true
+        service_hash = {}
+        service_hash['name'] = line_array[0]
+        service_hash['load'] = line_array[1]
+        service_hash['active'] = line_array[2]
+        service_hash['sub'] = line_array[3]
+        service_hash['description'] = line_array[4]
+        service_array.push(service_hash)
+      end
     end
     service_array
   end
 
   def check_systemd
-    @services.reject { |service| validate_presence_of(service) }.each do |gone|
-      @crit_service << "#{gone} - Not Present"
+     unless @services.nil?
+       @services.reject { |service| validate_presence_of(service) }.each do |gone|
+          @crit_service << "#{gone} - Not Present"
+       end
+    end
+    if @services.nil? && @failed == false
+        critical "You must define services to check!"  
     end
 
     unit_services.each do |service|

--- a/bin/check-systemd.rb
+++ b/bin/check-systemd.rb
@@ -70,7 +70,6 @@ class CheckSystemd < Sensu::Plugin::Check::CLI
     service_array = []
     systemd_output.split("\n").each do |line|
       line_array = line.split(' ')
-      next unless @services.any? { |service| line_array[0].include?(service) } || @failed == true
       next if @failed_ignore.any? { |service| line_array[0].include?(service) } && @failed == true
       service_hash = {}
       service_hash['name'] = line_array[0]

--- a/bin/check-systemd.rb
+++ b/bin/check-systemd.rb
@@ -71,15 +71,14 @@ class CheckSystemd < Sensu::Plugin::Check::CLI
     systemd_output.split("\n").each do |line|
       line_array = line.split(' ')
       next unless @services.any? { |service| line_array[0].include?(service) } || @failed == true
-      unless @failed_ignore.any? { |service| line_array[0].include?(service) } && @failed == true
-        service_hash = {}
-        service_hash['name'] = line_array[0]
-        service_hash['load'] = line_array[1]
-        service_hash['active'] = line_array[2]
-        service_hash['sub'] = line_array[3]
-        service_hash['description'] = line_array[4]
-        service_array.push(service_hash)
-      end
+      next if @failed_ignore.any? { |service| line_array[0].include?(service) } && @failed == true
+      service_hash = {}
+      service_hash['name'] = line_array[0]
+      service_hash['load'] = line_array[1]
+      service_hash['active'] = line_array[2]
+      service_hash['sub'] = line_array[3]
+      service_hash['description'] = line_array[4]
+      service_array.push(service_hash)
     end
     service_array
   end
@@ -87,7 +86,7 @@ class CheckSystemd < Sensu::Plugin::Check::CLI
   def check_systemd
     unless @services.nil?
       @services.reject { |service| validate_presence_of(service) }.each do |gone|
-         @crit_service << "#{gone} - Not Present"
+        @crit_service << "#{gone} - Not Present"
       end
     end
     if @services.none? && @failed == false

--- a/bin/check-systemd.rb
+++ b/bin/check-systemd.rb
@@ -26,7 +26,6 @@
 #
 
 require 'sensu-plugin/check/cli'
-
 #
 #  Check systemd services
 #
@@ -44,7 +43,7 @@ class CheckSystemd < Sensu::Plugin::Check::CLI
          description: 'all services are being checked. One or more failed => CRITICAL'
   option :failed_ignore,
          short: '-i SERVICES',
-         proc: proc { |a| a.split(',')},
+         proc: proc { |a| a.split(',') },
          default: [],
          long: '--failed-ignore',
          description: 'comma seperated list of services which should be ignored when using --failed mode'
@@ -88,11 +87,11 @@ class CheckSystemd < Sensu::Plugin::Check::CLI
   def check_systemd
     unless @services.nil?
       @services.reject { |service| validate_presence_of(service) }.each do |gone|
-          @crit_service << "#{gone} - Not Present"
-       end
+         @crit_service << "#{gone} - Not Present"
+      end
     end
-    if !@services.any? && @failed == false
-      critical "You must define services to check!"
+    if @services.none? && @failed == false
+      critical 'You must define services to check!'
     end
 
     unit_services.each do |service|

--- a/bin/check-systemd.rb
+++ b/bin/check-systemd.rb
@@ -33,7 +33,7 @@ require 'sensu-plugin/check/cli'
 class CheckSystemd < Sensu::Plugin::Check::CLI
   option :services,
          short: '-s SERVICES',
-         proc: proc { |a| a.split(',')},
+         proc: proc { |a| a.split(',') },
          default: [],
          description: 'comma seperated list of services to check. ignored if --failed is set'
   option :failed,
@@ -55,7 +55,7 @@ class CheckSystemd < Sensu::Plugin::Check::CLI
     super
     @services = config[:services]
     @failed = config[:failed]
-    @failed_ignore =  config[:failed_ignore]
+    @failed_ignore = config[:failed_ignore]
     @crit_service = []
   end
 
@@ -86,13 +86,13 @@ class CheckSystemd < Sensu::Plugin::Check::CLI
   end
 
   def check_systemd
-     unless @services.nil?
-       @services.reject { |service| validate_presence_of(service) }.each do |gone|
+    unless @services.nil?
+      @services.reject { |service| validate_presence_of(service) }.each do |gone|
           @crit_service << "#{gone} - Not Present"
        end
     end
-    if @services.nil? && @failed == false
-        critical "You must define services to check!"  
+    if !@services.any? && @failed == false
+      critical "You must define services to check!"
     end
 
     unit_services.each do |service|

--- a/check-systemd.rb.patch
+++ b/check-systemd.rb.patch
@@ -1,0 +1,74 @@
+diff --git a/bin/check-systemd.rb b/bin/check-systemd.rb
+index 999086d..9f6a6a8 100755
+--- a/bin/check-systemd.rb
++++ b/bin/check-systemd.rb
+@@ -31,13 +31,29 @@ require 'sensu-plugin/check/cli'
+ class CheckSystemd < Sensu::Plugin::Check::CLI
+   option :services,
+          short: '-s SERVICES',
+-         proc: proc { |a| a.split(',') }
++         proc: proc { |a| a.split(',')},
++         default: [],
++         description: 'comma seperated list of services to check. ignored if --failed is set'
++  option :failed,
++         short: '-f',
++         boolean: true,
++         default: false,
++         long: '--failed',
++         description: 'all services are being checked. One or more failed => CRITICAL'
++  option :failed_ignore,
++         short: '-i SERVICES',
++         proc: proc { |a| a.split(',')},
++         default: [],
++         long: '--failed-ignore',
++         description: 'comma seperated list of services which should be ignored when using --failed mode'
+ 
+   # Setup variables
+   #
+   def initialize
+     super
+     @services = config[:services]
++    @failed = config[:failed]
++    @failed_ignore =  config[:failed_ignore]
+     @crit_service = []
+   end
+ 
+@@ -53,21 +69,28 @@ class CheckSystemd < Sensu::Plugin::Check::CLI
+     service_array = []
+     systemd_output.split("\n").each do |line|
+       line_array = line.split(' ')
+-      next unless @services.any? { |service| line_array[0].include?(service) }
+-      service_hash = {}
+-      service_hash['name'] = line_array[0]
+-      service_hash['load'] = line_array[1]
+-      service_hash['active'] = line_array[2]
+-      service_hash['sub'] = line_array[3]
+-      service_hash['description'] = line_array[4]
+-      service_array.push(service_hash)
++      next unless @services.any? { |service| line_array[0].include?(service) } || @failed == true
++      unless @failed_ignore.any? { |service| line_array[0].include?(service) } && @failed == true
++        service_hash = {}
++        service_hash['name'] = line_array[0]
++        service_hash['load'] = line_array[1]
++        service_hash['active'] = line_array[2]
++        service_hash['sub'] = line_array[3]
++        service_hash['description'] = line_array[4]
++        service_array.push(service_hash)
++      end
+     end
+     service_array
+   end
+ 
+   def check_systemd
+-    @services.reject { |service| validate_presence_of(service) }.each do |gone|
+-      @crit_service << "#{gone} - Not Present"
++     unless @services.nil?
++       @services.reject { |service| validate_presence_of(service) }.each do |gone|
++          @crit_service << "#{gone} - Not Present"
++       end
++    end
++    if @services.nil? && @failed == false
++        critical "You must define services to check!"  
+     end
+ 
+     unit_services.each do |service|

--- a/lib/sensu-plugins-systemd.rb
+++ b/lib/sensu-plugins-systemd.rb
@@ -1,2 +1,1 @@
-
 require 'sensu-plugins-systemd/version'

--- a/sensu-plugins-systemd.gemspec
+++ b/sensu-plugins-systemd.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'date'
@@ -40,7 +40,7 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.add_development_dependency 'pry',                       '~> 0.10'
   s.add_development_dependency 'rake',                      '~> 10.5'
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
-  s.add_development_dependency 'rubocop',                   '~> 0.37'
   s.add_development_dependency 'rspec',                     '~> 3.4'
+  s.add_development_dependency 'rubocop',                   '~> 0.37'
   s.add_development_dependency 'yard',                      '~> 0.8'
 end

--- a/sensu-plugins-systemd.gemspec
+++ b/sensu-plugins-systemd.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'date'
@@ -24,7 +24,6 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.summary       = 'This provides functionality to check systemd services.'
   s.description   = 'Plugins to provide functionality to check systemd services for Sensu, a monitoring framework'
   s.license       = 'MIT'
-  s.has_rdoc      = false
   s.require_paths = ['lib']
   s.files         = Dir.glob('{bin,lib}/**/*') + %w[LICENSE README.md CHANGELOG.md]
   # s.test_files    = Dir['test/*.rb']
@@ -40,7 +39,7 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.add_development_dependency 'pry',                       '~> 0.10'
   s.add_development_dependency 'rake',                      '~> 10.5'
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
-  s.add_development_dependency 'rubocop',                   '~> 0.37'
   s.add_development_dependency 'rspec',                     '~> 3.4'
+  s.add_development_dependency 'rubocop',                   '~> 0.37'
   s.add_development_dependency 'yard',                      '~> 0.8'
 end


### PR DESCRIPTION
 Added 'failed' Mode. This Mode checks all systemd service and reports only CRITICAL if any service has state "failed". I added the cause i wanted to monitor all my services on my linux (EL7) Hosts.

The name "failed mode" may not be the best - but I couldn't think of anything better. Maybe someone's got a better idea.

This is my first modification of a Ruby Script - hope my code is not too ugly....

## Pull Request Checklist

**Is this in reference to an existing issue?**
No

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] Update README with any necessary configuration snippets

~- [] Binstubs are created if needed~

- [x] RuboCop passes

~- [] Existing tests pass~

#### Purpose

#### Known Compatibility Issues
